### PR TITLE
Fix comma placement in complimentary close

### DIFF
--- a/lib.typ
+++ b/lib.typ
@@ -133,7 +133,7 @@
 
     #v(1em)
 
-    Mit freundlichen Grüßen,
+    Mit freundlichen Grüßen
 
     #v(1em)
 


### PR DESCRIPTION
According to [Duden](https://www.duden.de/sprachwissen/sprachratgeber/Die-Gru%C3%9Fformel-in-Brief-und-E-Mail), it is not correct to set a comma in the complimentary close. So, I removed the comma after Mit freundlichen Grüßen.