### PR TITLE
Import data in a structured way

### DIFF
--- a/lib.typ
+++ b/lib.typ
@@ -40,7 +40,7 @@
   }
 
 
-  // Uses the values from data. If a value is not set, it is take from parameters as default.
+  // Uses the values from data. If no value is set, it is taken from parameters as default.
   if data != none {
     invoice-nr = data.at("invoice-nr", default: invoice-nr)
     invoice-date = if data.at("invoice-date") != none {

--- a/lib.typ
+++ b/lib.typ
@@ -5,22 +5,65 @@
 // Generates an invoice
 #let invoice(
   // The invoice number
-  invoice-nr,
+  invoice-nr: none,
   // The date on which the invoice was created
-  invoice-date,
+  invoice-date: none,
   // A list of items
-  items,
+  items: (),
   // Name and postal address of the author
-  author,
+  author: (:),
   // Name and postal address of the recipient
-  recipient,
+  recipient: (:),
   // Name and bank account details of the entity receiving the money
-  bank-account,
+  bank-account: (:),
+  // data to use instead of parameters given to this function
+  data: none,
   // Optional VAT
   vat: 0.19,
   // Check if the german § 19 UStG applies
   kleinunternehmer: false,
 ) = {
+
+  let parse-date = (date-str) => {
+    let parts = date-str.split("-")
+    if parts.len() != 3 {
+      panic(
+        "Invalid date string: " + date-str + "\n" +
+        "Expected format: YYYY-MM-DD"
+      )
+    }
+    datetime(
+      year: int(parts.at(0)),
+      month: int(parts.at(1)),
+      day: int(parts.at(2)),
+    )
+  }
+
+
+  // Uses the values from data. If a value is not set, it is take from parameters as default.
+  if data != none {
+    invoice-nr = data.at("invoice-nr", default: invoice-nr)
+    invoice-date = if data.at("invoice-date") != none {
+      parse-date(data.at("invoice-date"))
+    } else {
+      invoice-date
+    }
+    items = data.at("items", default: items)
+    author = if data.author != none {
+      author = data.author
+      if author.signature != none {
+        author.signature = image(author.signature, width: 5em)
+      }
+      author
+    } else {
+      author
+    }
+    recipient = data.at("recipient", default: recipient)
+    bank-account = data.at("bank-account")
+    vat = data.at("vat", default: vat)
+    kleinunternehmer = data.at("kleinunternehmer", default: kleinunternehmer)
+  }
+
   set text(lang: "de", region: "DE")
 
   set page(paper: "a4", margin: (x: 20%, y: 20%, top: 20%, bottom: 20%))

--- a/template/data.yaml
+++ b/template/data.yaml
@@ -1,0 +1,31 @@
+invoice-nr: 2023-001
+invoice-date: 2024-09-03
+kleinunternehmer: true
+vat: 0.19
+author:
+  name: 'Kerstin Humm'
+  street: 'Straße der Privatsphäre und Stille 1'
+  zip: '54321'
+  city: 'Potsdam'
+  tax_nr: '12345/67890'
+  # optional signature, can be omitted
+  signature: 'example_signature.png'
+recipient:
+  name: 'Erika Mustermann'
+  street: 'Musterallee'
+  zip: '12345'
+  city: 'Musterstadt'
+bank-account:
+  name: 'Todd Name'
+  bank: 'Deutsche Postbank AG'
+  iban: 'DE89370400440532013000'
+  bic: 'PBNKDEFF'
+  # There is currently only one gendered term in this template.
+  # You can overwrite it, or omit it and just choose the default.
+  gender:
+    account_holder: 'Kontoinhaberin'
+items:
+  - description: 'The first service provided. The first service provided. The first service provided'
+    price: 200
+  - description: 'The second service provided'
+    price: 150.2

--- a/template/main_yaml.typ
+++ b/template/main_yaml.typ
@@ -1,0 +1,5 @@
+#import "@preview/classy-german-invoice:0.3.1": invoice
+
+#show: invoice(
+  data: yaml("data.yaml")
+)


### PR DESCRIPTION
This PR adds a feature to generate invoices from structured data. In the example I have chosen yaml, but in theory all types that typst offers could be used.

Unfortunately I had to do some work to validate the values from `data`. This is because the `invoice` function expects objects for `invoice-date` and `signature`. In my opinion, the function should only accept primitive data types and create the respective objects in the function body. However, this would change the current API and therefore not be backwards compatible.

If that works for you I could create a PR to address the issue but for now I just wanted to address the data issue.

fixes #6 