### PR TITLE
Add feature to display due date in invoice-text

### DIFF
--- a/lib.typ
+++ b/lib.typ
@@ -5,8 +5,8 @@
 #let invoice(
   // The invoice number
   invoice-nr,
-  // The date on which the invoice was created
-  invoice-date,
+  // The date on which the invoice was created or issued. Default is today
+  issuing-date: datetime.today(),
   // A list of items
   items,
   // Name and postal address of the author
@@ -15,10 +15,13 @@
   recipient,
   // Name and bank account details of the entity receiving the money
   bank-account,
-  // The text to display below the items
+  // A plain string that will be evaluated as markup and displayed below the invoice items.
+  // Possible variabes:
+  //   - due-date
   invoice-text: "Vielen Dank für die Zusammenarbeit. Die Rechnungssumme überweisen Sie bitte
-    innerhalb von 14 Tagen ohne Abzug auf mein unten genanntes Konto unter Nennung
-    der Rechnungsnummer.",
+    bis zum *#due-date* ohne Abzug auf mein unten genanntes Konto unter Nennung der Rechnungsnummer.",
+  // Days until the invoice should be paid
+  due-days: 14,
   // Optional VAT
   vat: 0.19,
   // Check if the german § 19 UStG applies
@@ -50,6 +53,11 @@
     }
   }
 
+  let due_date(issuing-date, days) = {
+    issuing-date + duration(days: days)
+  }
+  let due-date = due_date(issuing-date, due-days)
+
   set text(number-type: "old-style")
 
   smallcaps[
@@ -75,7 +83,7 @@
     Rechnung \##invoice-nr
   ], [
     #set align(right)
-    #author.city, *#invoice-date.display("[day].[month].[year]")*
+    #author.city, *#issuing-date.display("[day].[month].[year]")*
   ])
 
   let total = items.map((item) => item.price).sum()
@@ -125,7 +133,7 @@
 
   [
     #set text(size: 0.8em)
-    #invoice-text
+    #eval(invoice-text, mode: "markup", scope: (due-date: due-date.display("[day].[month].[year]")))
     #if kleinunternehmer [
       Gemäß § 19 UStG wird keine Umsatzsteuer berechnet.
     ]

--- a/template/main.typ
+++ b/template/main.typ
@@ -4,7 +4,7 @@
   // Invoice number
   "2023-001",
   // Invoice date
-  datetime(year: 2024, month: 09, day: 03),
+  issuing-date: datetime(year: 2024, month: 09, day: 03),
   // Items
   (
     (
@@ -43,6 +43,9 @@
     // You can overwrite it, or omit it and just choose the default.
     gender: (account_holder: "Kontoinhaberin")
   ),
+  // A text that will be evaluated to markup.
+  invoice-text: "Vielen Dank für die Zusammenarbeit. Die Rechnungssumme überweisen Sie bitte
+    bis zum *#due-date* ohne Abzug auf mein unten genanntes Konto unter Nennung der Rechnungsnummer.",
   // Umsatzsteuersatz (VAT)
   vat: 0.19,
   kleinunternehmer: true,


### PR DESCRIPTION
Setting a default value to issuing-date is a breaking change, but I thought it would be a good idea.
Also is pretty easy now to expose more variables that we calculate to the caller. For example total sum or vat.

closes #10 