### PR TITLE
add service date

### DIFF
--- a/lib.typ
+++ b/lib.typ
@@ -15,6 +15,8 @@
   recipient,
   // Name and bank account details of the entity receiving the money
   bank-account,
+  // The date when the service or the delivery happend
+  service-date: none,
   // The text to display below the items
   invoice-text: "Vielen Dank für die Zusammenarbeit. Die Rechnungssumme überweisen Sie bitte
     innerhalb von 14 Tagen ohne Abzug auf mein unten genanntes Konto unter Nennung
@@ -49,6 +51,21 @@
       s
     }
   }
+
+  let months = (
+    "Januar",
+    "Februar",
+    "März",
+    "April",
+    "Mai",
+    "Juni",
+    "Juli",
+    "August",
+    "September",
+    "Oktober",
+    "November",
+    "Dezember"
+    )
 
   set text(number-type: "old-style")
 
@@ -125,7 +142,12 @@
 
   [
     #set text(size: 0.8em)
-    #invoice-text
+    #invoice-text\ \
+    #if service-date == none [
+      Das Leistungs- bzw. Lieferdatum entspricht dem Rechnungsdatum.\
+    ] else [
+      Leistung bzw. Lieferung im *#months.at(service-date.month() -1) #service-date.year()*.\
+    ]
     #if kleinunternehmer [
       Gemäß § 19 UStG wird keine Umsatzsteuer berechnet.
     ]

--- a/template/main.typ
+++ b/template/main.typ
@@ -1,4 +1,4 @@
-#import "@preview/classy-german-invoice:0.3.1": invoice
+#import "../lib.typ": invoice
 
 #show: invoice(
   // Invoice number
@@ -13,7 +13,7 @@
     ),
     (
       description: "The second service provided",
-      price: 150.2
+      price: 150.2,
     ),
   ),
   // Author
@@ -24,7 +24,7 @@
     city: "Potsdam",
     tax_nr: "12345/67890",
     // optional signature, can be omitted
-    signature: image("example_signature.png", width: 5em)
+    signature: image("example_signature.png", width: 5em),
   ),
   // Recipient
   (
@@ -41,8 +41,9 @@
     bic: "PBNKDEFF",
     // There is currently only one gendered term in this template.
     // You can overwrite it, or omit it and just choose the default.
-    gender: (account_holder: "Kontoinhaberin")
+    gender: (account_holder: "Kontoinhaberin"),
   ),
+  // service-date: datetime(year: 2024, month: 09, day: 01),
   // Umsatzsteuersatz (VAT)
   vat: 0.19,
   kleinunternehmer: true,


### PR DESCRIPTION
First draft to add a service date.
If no date is given it will print a default phrase.
If a date is given only the year and the month will be printed since it [allowed](https://www.gesetze-im-internet.de/ustdv_1980/__31.html) and often preferred.

closes #15 