### PR TITLE
Adds support for country in author and recipient

### DIFF
--- a/lib.typ
+++ b/lib.typ
@@ -56,6 +56,7 @@
     *#author.name* •
     #author.street •
     #author.zip #author.city
+    #if "country" in author [• #author.country ] else []
   ]
 
   v(1em)
@@ -65,8 +66,8 @@
     #set text(size: 1.2em)
     #recipient.name \
     #recipient.street \
-    #recipient.zip
-    #recipient.city
+    #recipient.zip #recipient.city \
+    #if "country" in recipient [#recipient.country ] else []
   ]
 
   v(4em)


### PR DESCRIPTION
Adds support for a "country" field in the "author" and "recipient". The field is optional and if not provided outputs the exact PDF as before. The recipient country fits without problem into the template, the author country overflows the header line with the example data provided in the readme with "Deutschland" added. Most streetnames should be short enough to fit well though.