### PR TITLE
Small fixes and adjustments to the layout

### DIFF
--- a/lib.typ
+++ b/lib.typ
@@ -16,9 +16,11 @@
   // Name and bank account details of the entity receiving the money
   bank-account,
   // The text to display below the items
-  invoice-text: "Vielen Dank für die Zusammenarbeit. Die Rechnungssumme überweisen Sie bitte
+  invoice-text: [
+    Vielen Dank für die Zusammenarbeit. Die Rechnungssumme überweisen Sie bitte
     innerhalb von 14 Tagen ohne Abzug auf mein unten genanntes Konto unter Nennung
-    der Rechnungsnummer.",
+    der Rechnungsnummer.
+  ],
   // Optional VAT
   vat: 0.19,
   // Check if the german § 19 UStG applies
@@ -154,6 +156,7 @@
   [
     #set text(size: 0.8em)
     #invoice-text
+
     #if kleinunternehmer [
       Gemäß § 19 UStG wird keine Umsatzsteuer berechnet.
     ]

--- a/lib.typ
+++ b/lib.typ
@@ -30,7 +30,7 @@
 ) = {
   set text(lang: "de", region: "DE")
 
-  set page(paper: "a4", margin: (x: 20%, y: 20%, top: 20%, bottom: 20%))
+  set page(paper: "a4", margin: (x: 20%, y: 20%, top: 20%, bottom: 10%))
 
   // Typst can't format numbers yet, so we use this from here:
   // https://github.com/typst/typst/issues/180#issuecomment-1484069775
@@ -184,11 +184,9 @@
     ]
   )
 
+  v(2em)
+
   [
-    Steuernummer: #author.tax_nr
-
-    #v(0.5em)
-
     Mit freundlichen Grüßen
 
     #if "signature" in author [
@@ -198,5 +196,8 @@
     ]
 
     #author.name
+
+    #set text(size: 0.8em)
+    Steuernummer: #author.tax_nr
   ]
 }

--- a/lib.typ
+++ b/lib.typ
@@ -170,16 +170,19 @@
     "BCD\n" + "002\n" + "1\n" + "SCT\n" + bank-account.bic + "\n" + bank-account.name + "\n" + bank-account.iban + "\n" + "EUR" + format_currency(total, locale: "en") + "\n" + "\n" + invoice-nr + "\n" + "\n" + "\n"
   )
 
-  grid(columns: 2, gutter: 1em, align: top, [
-    #set par(leading: 0.40em)
-    #set text(number-type: "lining")
-    #(bank-account
-      .at("gender", default: (:))
-      .at("account_holder", default: "Kontoinhaberin")): #bank-account.name \
-    Kreditinstitut: #bank-account.bank \
-    IBAN: *#iban(bank-account.iban)* \
-    BIC: #bank-account.bic
-  ], qr-code(epc-qr-content, height: 4em))
+  grid(columns: 2, gutter: 1em, align: top,
+    qr-code(epc-qr-content, height: 4em),
+    [
+      #set par(leading: 0.40em)
+      #set text(number-type: "lining")
+      #(bank-account
+        .at("gender", default: (:))
+        .at("account_holder", default: "Kontoinhaberin")): #bank-account.name \
+      Kreditinstitut: #bank-account.bank \
+      IBAN: *#iban(bank-account.iban)* \
+      BIC: #bank-account.bic
+    ]
+  )
 
   [
     Steuernummer: #author.tax_nr

--- a/lib.typ
+++ b/lib.typ
@@ -170,7 +170,7 @@
     "BCD\n" + "002\n" + "1\n" + "SCT\n" + bank-account.bic + "\n" + bank-account.name + "\n" + bank-account.iban + "\n" + "EUR" + format_currency(total, locale: "en") + "\n" + "\n" + invoice-nr + "\n" + "\n" + "\n"
   )
 
-  grid(columns: (1fr, 1fr), gutter: 1em, align: top, [
+  grid(columns: 2, gutter: 1em, align: top, [
     #set par(leading: 0.40em)
     #set text(number-type: "lining")
     #(bank-account


### PR DESCRIPTION
This PR includes several small fixes and adjustments to the invoice layout:

1. Format the invoice-text to remove unwanted line breaks and extra spaces. Added a line break between the invoice-text and the "Kleinunternehmer" phrase
2. Set the column width of the bank details to auto, so longer bank names fit properly
3. Swap the position of bank details and QR code for a cleaner look
4. Move the tax number below the author name, reduce its font size, and adjust spacing and bottom margin
